### PR TITLE
fix: there are different versions for different macos

### DIFF
--- a/webpbin.go
+++ b/webpbin.go
@@ -65,6 +65,41 @@ func DetectUnsupportedPlatforms() {
 }
 
 func createBinWrapper(optionFuncs ...OptionFunc) *binwrapper.BinWrapper {
+	macVersionMap := map[string]string{
+		"0.4.1":     "10.8-2",
+		"0.4.1-rc1": "10.8",
+		"0.4.2":     "10.8",
+		"0.4.2-rc2": "10.8",
+		"0.4.3":     "10.9",
+		"0.4.3-rc1": "10.9",
+		"0.4.4":     "10.9",
+		"0.4.4-rc2": "10.9",
+		"0.5.0":     "10.9",
+		"0.5.0-rc1": "10.9",
+		"0.5.1":     "10.9",
+		"0.5.1-rc5": "10.9",
+		"0.5.2":     "10.9",
+		"0.5.2-rc2": "10.9",
+		"0.6.0":     "10.12",
+		"0.6.0-rc2": "10.12",
+		"0.6.0-rc3": "10.12",
+		"0.6.1":     "10.12",
+		"0.6.1-rc2": "10.12",
+		"1.0.0":     "10.13",
+		"1.0.0-rc1": "10.13",
+		"1.0.0-rc2": "10.13",
+		"1.0.0-rc3": "10.13",
+		"1.0.1":     "10.13",
+		"1.0.1-rc2": "10.13",
+		"1.0.2":     "10.14",
+		"1.0.2-rc1": "10.14",
+		"1.0.3":     "10.14",
+		"1.0.3-rc1": "10.14",
+		"1.1.0":     "10.15",
+		"1.1.0-rc2": "10.15",
+		"1.2.0":     "10.15",
+		"1.2.0-rc3": "10.15",
+	}
 	base := "https://storage.googleapis.com/downloads.webmproject.org/releases/webp/"
 
 	b := binwrapper.NewBinWrapper().AutoExe()
@@ -78,7 +113,7 @@ func createBinWrapper(optionFuncs ...OptionFunc) *binwrapper.BinWrapper {
 	if !skipDownload {
 		b.Src(
 			binwrapper.NewSrc().
-				URL(base + "libwebp-" + libwebpVersion + "-mac-10.12.tar.gz").
+				URL(base + "libwebp-" + libwebpVersion + "-mac-" + macVersionMap[libwebpVersion] + ".tar.gz").
 				Os("darwin")).
 			Src(
 				binwrapper.NewSrc().


### PR DESCRIPTION
Base on the webp lib releases. (https://storage.googleapis.com/downloads.webmproject.org/releases/webp/index.html)
The different versions of libwebp connect with different MacOS.

For example, there is libwebp version `0.6.0` connects with `mac-10.12` [libwebp-0.6.0-mac-10.12.tar.gz](https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-0.6.0-mac-10.12.tar.gz), and version `1.1.0` connects with `mac-10.15` [libwebp-1.1.0-mac-10.15.tar.gz](https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-1.1.0-mac-10.15.tar.gz).

The version map can solve the missing file problem for the releases for now, but is not available for the future releases.
