### PR TITLE
Support gif converts to webp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
+.bin
 .idea
 *.iml
 vendor
+source.gif
 source.jpg
 source.webp

--- a/cwebp_test.go
+++ b/cwebp_test.go
@@ -1,49 +1,18 @@
 package webpbin
 
 import (
-	"net/http"
-	"os"
-	"io"
-	"github.com/stretchr/testify/assert"
-	"testing"
 	"image/jpeg"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
 	"golang.org/x/image/webp"
-	"fmt"
 )
 
 func init() {
 	DetectUnsupportedPlatforms()
 	downloadFile("https://upload.wikimedia.org/wikipedia/commons/e/e3/Avola-Syracuse-Sicilia-Italy_-_Creative_Commons_by_gnuckx_%283858115914%29.jpg", "source.jpg")
 	downloadFile("https://upload.wikimedia.org/wikipedia/commons/d/d1/Snail_in_Forest_on_Lichtscheid_2.webp", "source.webp")
-}
-
-func downloadFile(url, target string) {
-	_, err := os.Stat(target)
-
-	if err != nil {
-		resp, err := http.Get(url)
-
-		if err != nil {
-			fmt.Printf("Error while downloading test image: %v\n", err)
-			panic(err)
-		}
-
-		defer resp.Body.Close()
-
-		f, err := os.Create(target)
-
-		if err != nil {
-			panic(err)
-		}
-
-		defer f.Close()
-
-		_, err = io.Copy(f, resp.Body)
-
-		if err != nil {
-			panic(err)
-		}
-	}
 }
 
 func TestEncodeImage(t *testing.T) {

--- a/dwebp_test.go
+++ b/dwebp_test.go
@@ -1,11 +1,12 @@
 package webpbin
 
 import (
-	"testing"
-	"github.com/stretchr/testify/assert"
-	"os"
-	"golang.org/x/image/webp"
 	"image/png"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/image/webp"
 )
 
 func TestVersionDWebP(t *testing.T) {

--- a/gif2webp.go
+++ b/gif2webp.go
@@ -1,0 +1,166 @@
+package webpbin
+
+import (
+	"errors"
+	"fmt"
+	"image/gif"
+	"io"
+
+	"github.com/nickalie/go-binwrapper"
+)
+
+// Gif2WebP converts a GIF image to a WebP image.
+// https://developers.google.com/speed/webp/docs/gif2webp
+type Gif2WebP struct {
+	*binwrapper.BinWrapper
+	inputFile  string
+	inputImage *gif.GIF
+	input      io.Reader
+	outputFile string
+	output     io.Writer
+	quality    int
+}
+
+// NewGif2WebP creates new Gif2WebP instance.
+func NewGif2WebP(optionFuncs ...OptionFunc) *Gif2WebP {
+	bin := &Gif2WebP{
+		BinWrapper: createBinWrapper(optionFuncs...),
+		quality:    -1,
+	}
+	bin.ExecPath("gif2webp")
+
+	return bin
+}
+
+// Version returns gif2webp version.
+func (c *Gif2WebP) Version() (string, error) {
+	return version(c.BinWrapper)
+}
+
+// InputFile sets image file to convert.
+// Input or InputImage called before will be ignored.
+func (c *Gif2WebP) InputFile(file string) *Gif2WebP {
+	c.input = nil
+	c.inputImage = nil
+	c.inputFile = file
+	return c
+}
+
+// Input sets reader to convert.
+// InputFile or InputImage called before will be ignored.
+func (c *Gif2WebP) Input(reader io.Reader) *Gif2WebP {
+	c.inputFile = ""
+	c.inputImage = nil
+	c.input = reader
+	return c
+}
+
+// InputImage sets image to convert.
+// InputFile or Input called before will be ignored.
+func (c *Gif2WebP) InputImage(img *gif.GIF) *Gif2WebP {
+	c.inputFile = ""
+	c.input = nil
+	c.inputImage = img
+	return c
+}
+
+// OutputFile specify the name of the output WebP file.
+// Output called before will be ignored.
+func (c *Gif2WebP) OutputFile(file string) *Gif2WebP {
+	c.output = nil
+	c.outputFile = file
+	return c
+}
+
+// Output specify writer to write webp file content.
+// OutputFile called before will be ignored.
+func (c *Gif2WebP) Output(writer io.Writer) *Gif2WebP {
+	c.outputFile = ""
+	c.output = writer
+	return c
+}
+
+// Quality specify the compression factor for RGB channels between 0 and 100. The default is 75.
+//
+// A small factor produces a smaller file with lower quality. Best quality is achieved by using a value of 100.
+func (c *Gif2WebP) Quality(quality uint) *Gif2WebP {
+	if quality > 100 {
+		quality = 100
+	}
+
+	c.quality = int(quality)
+	return c
+}
+
+// Run starts gif2webp with specified parameters.
+func (c *Gif2WebP) Run() error {
+	defer c.BinWrapper.Reset()
+
+	if c.quality > -1 {
+		c.Arg("-q", fmt.Sprintf("%d", c.quality))
+	}
+
+	output, err := c.getOutput()
+
+	if err != nil {
+		return err
+	}
+
+	c.Arg("-o", output)
+
+	err = c.setInput()
+
+	if err != nil {
+		return err
+	}
+
+	if c.output != nil {
+		c.SetStdOut(c.output)
+	}
+
+	err = c.BinWrapper.Run()
+
+	if err != nil {
+		return errors.New(err.Error() + ". " + string(c.StdErr()))
+	}
+
+	return nil
+}
+
+// Reset all parameters to default values
+func (c *Gif2WebP) Reset() *Gif2WebP {
+	c.quality = -1
+	return c
+}
+
+func (c *Gif2WebP) setInput() error {
+	if c.input != nil {
+		c.Arg("--").Arg("-")
+		c.StdIn(c.input)
+	} else if c.inputImage != nil {
+		r, err := createReaderFromGIF(c.inputImage)
+
+		if err != nil {
+			return err
+		}
+
+		c.Arg("--").Arg("-")
+		c.StdIn(r)
+	} else if c.inputFile != "" {
+		c.Arg(c.inputFile)
+	} else {
+		return errors.New("Undefined input")
+	}
+
+	return nil
+}
+
+func (c *Gif2WebP) getOutput() (string, error) {
+	if c.output != nil {
+		return "-", nil
+	} else if c.outputFile != "" {
+		return c.outputFile, nil
+	} else {
+		return "", errors.New("Undefined output")
+	}
+}

--- a/gif2webp_test.go
+++ b/gif2webp_test.go
@@ -1,0 +1,82 @@
+package webpbin
+
+import (
+	"image/gif"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func init() {
+	DetectUnsupportedPlatforms()
+	downloadFile("https://upload.wikimedia.org/wikipedia/commons/thumb/b/b7/CanadaLakeLouise_Bird.gif/240px-CanadaLakeLouise_Bird.gif", "source.gif")
+}
+
+func TestGifEncodeImage(t *testing.T) {
+	c := NewGif2WebP()
+	f, err := os.Open("source.gif")
+	assert.Nil(t, err)
+	img, err := gif.DecodeAll(f)
+	assert.Nil(t, err)
+	c.InputImage(img)
+	c.OutputFile("target.webp")
+	err = c.Run()
+	assert.Nil(t, err)
+	validateGifWebp(t)
+}
+
+func TestGifEncodeReader(t *testing.T) {
+	c := NewGif2WebP()
+	f, err := os.Open("source.gif")
+	assert.Nil(t, err)
+	c.Input(f)
+	c.OutputFile("target.webp")
+	err = c.Run()
+	assert.Nil(t, err)
+	validateGifWebp(t)
+}
+
+func TestGifEncodeFile(t *testing.T) {
+	c := NewGif2WebP()
+	c.InputFile("source.gif")
+	c.OutputFile("target.webp")
+	err := c.Run()
+	assert.Nil(t, err)
+	validateGifWebp(t)
+}
+
+func TestGifEncodeWriter(t *testing.T) {
+	f, err := os.Create("target.webp")
+	assert.Nil(t, err)
+	defer f.Close()
+
+	c := NewGif2WebP()
+	c.InputFile("source.gif")
+	c.Output(f)
+	err = c.Run()
+	assert.Nil(t, err)
+	f.Close()
+	validateGifWebp(t)
+}
+
+func TestGifVersionCWebP(t *testing.T) {
+	c := NewGif2WebP()
+	_, err := c.Version()
+	assert.Nil(t, err)
+}
+
+func validateGifWebp(t *testing.T) {
+	defer os.Remove("target.webp")
+	// We don't decode animated webp for check since it's implemented for now.
+	// fSource, err := os.Open("source.gif")
+	// assert.Nil(t, err)
+	// imgSource, err := gif.Decode(fSource)
+	// assert.Nil(t, err)
+	// fTarget, err := os.Open("target.webp")
+	// assert.Nil(t, err)
+	// defer fTarget.Close()
+	// imgTarget, err := webp.Decode(fTarget)
+	// assert.Nil(t, err)
+	// assert.Equal(t, imgSource.Bounds(), imgTarget.Bounds())
+}

--- a/test_util.go
+++ b/test_util.go
@@ -1,0 +1,37 @@
+package webpbin
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+)
+
+func downloadFile(url, target string) {
+	_, err := os.Stat(target)
+
+	if err != nil {
+		resp, err := http.Get(url)
+
+		if err != nil {
+			fmt.Printf("Error while downloading test image: %v\n", err)
+			panic(err)
+		}
+
+		defer resp.Body.Close()
+
+		f, err := os.Create(target)
+
+		if err != nil {
+			panic(err)
+		}
+
+		defer f.Close()
+
+		_, err = io.Copy(f, resp.Body)
+
+		if err != nil {
+			panic(err)
+		}
+	}
+}

--- a/webpbin.go
+++ b/webpbin.go
@@ -3,6 +3,7 @@ package webpbin
 import (
 	"bytes"
 	"image"
+	"image/gif"
 	"image/png"
 	"io"
 	"io/ioutil"
@@ -147,6 +148,17 @@ func createReaderFromImage(img image.Image) (io.Reader, error) {
 
 	var buffer bytes.Buffer
 	err := enc.Encode(&buffer, img)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &buffer, nil
+}
+
+func createReaderFromGIF(img *gif.GIF) (io.Reader, error) {
+	var buffer bytes.Buffer
+	err := gif.EncodeAll(&buffer, img)
 
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Wrap `gif2webp` bin for converting gif to webp.

BTW, the converted webp validation is skipped since the official webp doesn't support decoding animated webp for now.